### PR TITLE
Fix broken websocket communication.  Modern node switched to sending …

### DIFF
--- a/src/routes/Tracker.svelte
+++ b/src/routes/Tracker.svelte
@@ -21,6 +21,9 @@
 	import coopClient from '../services/coop-client.js';
 	import Map from "../components/Map.svelte";
 
+	//  Configure import objects
+	$coopClient.setEndpoint($page.url.searchParams.get('endpoint') || 'wss://localhost:8081/');
+
 	let { coopGuid } = $page.params;
 
 	// let tracker, trackerUpdated, actions, loadState, GlobalAction;

--- a/src/server/coop-wss-server.js
+++ b/src/server/coop-wss-server.js
@@ -45,8 +45,10 @@ wss.on('connection', function connection(ws, req) {
     //  Generate a userid for this connection
     ws.userid = crypto.randomUUID();
 
-    ws.on('message', function incoming(data) {
-        commManager.handleMessage(data, ws.userid, wss);
+    ws.on('message', function incoming(data, isBinary) {
+        const msg = isBinary ? data : data.toString();
+
+        commManager.handleMessage(msg, ws.userid, wss);
     });
 
     ws.on('close', () => {

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/services/coop-client.js
+++ b/src/services/coop-client.js
@@ -4,7 +4,7 @@ import storage from './storage.js';
 
 const coopClient = () => {
     //  TODO: Configurify
-    const endpoint = 'wss://z1m1-server.andypro.net:8081/';
+    let endpoint = 'wss://z1m1-server.andypro.net:8081/';
     let _pingTimer;
     const _pingTime = 45000;  //ms
     let conn;
@@ -16,6 +16,11 @@ const coopClient = () => {
     let _processDataCallback;
     let _processMetadataCallback;
 
+
+    const setEndpoint = (_endpoint) => {
+        endpoint = _endpoint;
+        console.log(`Coop endpoint set to ${_endpoint}`);
+    };
 
     const handlePing = () => {
         console.log('ping');
@@ -178,6 +183,7 @@ const coopClient = () => {
 
 
     return {
+        setEndpoint : setEndpoint,
         enable      : enable,
         disable     : disable,
         send        : send


### PR DESCRIPTION
…Buffer objects instead of strings, although I don't know when or how this started failing.

Added a setEndpoint() method to coop-client.js for easier local debugging with different servers.